### PR TITLE
Do not wrap certificate during base64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-user-kubeconfig: ## Create a user 'test-user' in the groups 'test-group' an
 .PHONY: admission-webhook
 admission-webhook: ## Install the Cedar validatingwebhookconfiguration
 	cat manifests/admission-webhook.yaml | \
-		sed -e "s/CA_BUNDLE_CONTENT/$(shell cat mount/certs/cedar-authorizer-server.crt | base64)/" | \
+		sed -e "s/CA_BUNDLE_CONTENT/$(shell cat mount/certs/cedar-authorizer-server.crt | base64 -w 0)/" | \
 		kubectl apply -f -
 
 ##@ Cedar Schema


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Avoid wrapping as it leads to the following error when running `make admission-webhook`

```
                kubectl apply -f -
Error from server (BadRequest): error when creating "STDIN": ValidatingWebhookConfiguration in version "v1" cannot be handled as a ValidatingWebhookConfiguration: illegal base64 data at input byte 76
make: *** [admission-webhook] Error 1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
