### PR TITLE
Fix Cedar Webhook startup issue: Add init container for certs permissions

### DIFF
--- a/manifests/cedar-authorization-webhook.yaml
+++ b/manifests/cedar-authorization-webhook.yaml
@@ -7,6 +7,13 @@ metadata:
   name: cedar-webhook
   namespace: kube-system
 spec:
+  initContainers:
+    - name: fix-cert-permissions
+      image: busybox
+      command: ["sh", "-c", "chown -R 65532:65532 /cedar-authorizer/certs && chmod -R g+rwX /cedar-authorizer/certs"]
+      volumeMounts:
+        - mountPath: /cedar-authorizer/certs
+          name: var-run-cedar-authorizer-certs
   containers:
     - name: cedar-webhook
       command:


### PR DESCRIPTION
## **Description of Changes**
- Adds an `initContainer` to `manifests/cedar-authorization-webhook.yaml` to handle permission adjustments for `/cedar-authorizer/certs/`.
- The init container runs before the main `cedar-webhook` container, ensuring the correct ownership and permissions for the certs directory.
- This prevents the API server from failing due to missing or inaccessible certificates.

## **Issue [#9](https://github.com/awslabs/cedar-access-control-for-k8s/issues/9)**
- Fixes **[#9](https://github.com/awslabs/cedar-access-control-for-k8s/issues/9)** where `cedar-webhook` fails to generate certificates due to permission errors and local cluster creation fails.

## **Testing**
- Successfully tested with `make kind`, verified that the webhook starts correctly.
- Examined pod logs to confirm the init container correctly modifies cert directory permissions.
- Confirmed that the API server no longer fails due to certificate access issues.

